### PR TITLE
fix: Nested container handling

### DIFF
--- a/Classes/Sizes/BackendLayout.php
+++ b/Classes/Sizes/BackendLayout.php
@@ -56,7 +56,7 @@ final class BackendLayout
         return $this->columns;
     }
 
-    public function getColumn(string $columnPosition): Column
+    public function getColumn(int $columnPosition): Column
     {
         return $this->columns[$columnPosition];
     }

--- a/Classes/Sizes/Container.php
+++ b/Classes/Sizes/Container.php
@@ -33,6 +33,8 @@ final class Container extends ContentElement
 
     private array $columns = [];
 
+    private Column $activeColumn;
+
     private readonly ConfigurationManager $configurationManager;
 
     public function __construct(array $data)
@@ -51,9 +53,19 @@ final class Container extends ContentElement
         return $this->columns;
     }
 
-    public function getColumn(string $columnPosition): Column
+    public function getColumn(int $columnPosition): Column
     {
         return $this->columns[$columnPosition];
+    }
+
+    public function setActiveColumn(Column $column): void
+    {
+        $this->activeColumn = $column;
+    }
+
+    public function getActiveColumn(): Column
+    {
+        return $this->activeColumn;
     }
 
     private function determineColumns(): void

--- a/Classes/Sizes/ContentElement.php
+++ b/Classes/Sizes/ContentElement.php
@@ -69,6 +69,10 @@ class ContentElement implements ContentElementInterface
 
     public function setParent(ContentElementInterface $contentElement): void
     {
+        if ($contentElement instanceof Container) {
+            $contentElement->setActiveColumn($contentElement->getColumn($this->colPos));
+        }
+
         $this->parent = $contentElement;
     }
 

--- a/Classes/Sizes/Rootline.php
+++ b/Classes/Sizes/Rootline.php
@@ -62,7 +62,7 @@ final class Rootline
 
         foreach (array_reverse($this->rootline) as $contentElement) {
             if ($contentElement instanceof Container) {
-                $multiplier[] = $contentElement->getColumn((string) $this->contentElement->getColPos())->getMultiplier();
+                $multiplier[] = $contentElement->getActiveColumn()->getMultiplier();
             }
         }
 
@@ -100,7 +100,7 @@ final class Rootline
     {
         if (array_key_exists($contentElement->getColPos(), $this->backendLayout->getColumns())) {
             $this->backendLayout->setActiveColumn(
-                $this->backendLayout->getColumn((string) $contentElement->getColPos())
+                $this->backendLayout->getColumn($contentElement->getColPos())
             );
 
             return;

--- a/Tests/Fixtures/container_example/Test/Fixtures/1col2colDatabase.php
+++ b/Tests/Fixtures/container_example/Test/Fixtures/1col2colDatabase.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'tt_content' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '2',
+            'hidden' => '0',
+            'sorting' => '1',
+            'CType' => 'example_container-1col',
+            'header' => '1col',
+            'deleted' => '0',
+            'starttime' => '0',
+            'endtime' => '0',
+            'colPos' => '0',
+            'sys_language_uid' => '0',
+            'tx_container_parent' => '0',
+        ],
+        1 => [
+            'uid' => '2',
+            'pid' => '2',
+            'hidden' => '0',
+            'sorting' => '1',
+            'CType' => 'example_container-2col-50-50',
+            'header' => '2col in 2col',
+            'deleted' => '0',
+            'starttime' => '0',
+            'endtime' => '0',
+            'colPos' => '101',
+            'sys_language_uid' => '0',
+            'tx_container_parent' => '1',
+        ],
+        2 => [
+            'uid' => '3',
+            'pid' => '2',
+            'hidden' => '0',
+            'sorting' => '1',
+            'CType' => 'image',
+            'header' => 'image in 2col in 1col',
+            'deleted' => '0',
+            'starttime' => '0',
+            'endtime' => '0',
+            'colPos' => '102',
+            'sys_language_uid' => '0',
+            'image' => '1',
+            'tx_container_parent' => '2',
+        ],
+    ],
+    'sys_file_reference' => [
+        0 => [
+            'uid' => '1',
+            'pid' => '2',
+            'uid_local' => '1',
+            'uid_foreign' => '3',
+            'tablenames' => 'tt_content',
+            'fieldname' => 'image',
+        ],
+    ],
+];

--- a/Tests/Functional/ContainerTest.php
+++ b/Tests/Functional/ContainerTest.php
@@ -101,6 +101,16 @@ class ContainerTest extends FunctionalTestCase
                 '4' => 'large 748.584 (min-width: 1480px)',
             ],
         ];
+        yield '2 Column in 1 Column' => [
+            '1col2colDatabase.php',
+            [
+                '0' => 'mobile 734 (max-width: 480px)',
+                '1' => 'mobile 704 (max-width: 767px)',
+                '2' => 'tablet 462 (max-width: 991px)',
+                '3' => 'default 562 (max-width: 1479px)',
+                '4' => 'large 562 (min-width: 1480px)',
+            ],
+        ];
         yield '2 Column in 2 Column' => [
             '2col2colDatabase.php',
             [


### PR DESCRIPTION
We had an issue when container element were nested.
If a content element was within an inner container colpos that does not exists in the outer container the column could not be resolved correctly.

We also fixed the types of the columnPosition methods.